### PR TITLE
Clusterable can now be of any type

### DIFF
--- a/dbscan.go
+++ b/dbscan.go
@@ -1,16 +1,12 @@
 package dbscan
 
-var eps = 0.2
-var minPts = 3
-
 const (
 	NOISE     = false
 	CLUSTERED = true
 )
 
 type Clusterable interface {
-	Distance(c Clusterable) float64
-	GetParams() []float64
+	Distance(c interface{}) float64
 }
 
 type Cluster []Clusterable

--- a/dbscan.go
+++ b/dbscan.go
@@ -7,23 +7,27 @@ const (
 
 type Clusterable interface {
 	Distance(c interface{}) float64
+	GetID() string
 }
 
 type Cluster []Clusterable
 
 func Clusterize(objects []Clusterable, minPts int, eps float64) []Cluster {
 	clusters := make([]Cluster, 0)
-	visited := map[Clusterable]bool{}
+	visited := map[string]bool{}
 	for _, point := range objects {
 		neighbours := findNeighbours(point, objects, eps)
-		if len(neighbours) >= minPts {
-			visited[point] = CLUSTERED
+		if len(neighbours)+1 >= minPts {
+			visited[point.GetID()] = CLUSTERED
 			cluster := make(Cluster, 1)
 			cluster[0] = point
 			cluster = expandCluster(cluster, neighbours, visited, minPts, eps)
-			clusters = append(clusters, cluster)
+
+			if len(cluster) >= minPts {
+				clusters = append(clusters, cluster)
+			}
 		} else {
-			visited[point] = NOISE
+			visited[point.GetID()] = NOISE
 		}
 	}
 	return clusters
@@ -35,7 +39,7 @@ func Clusterize(objects []Clusterable, minPts int, eps float64) []Cluster {
 func findNeighbours(point Clusterable, points []Clusterable, eps float64) []Clusterable {
 	neighbours := make([]Clusterable, 0)
 	for _, potNeigb := range points {
-		if point != potNeigb && potNeigb.Distance(point) <= eps {
+		if point.GetID() != potNeigb.GetID() && potNeigb.Distance(point) <= eps {
 			neighbours = append(neighbours, potNeigb)
 		}
 	}
@@ -43,20 +47,21 @@ func findNeighbours(point Clusterable, points []Clusterable, eps float64) []Clus
 }
 
 //Try to expand existing clutser
-func expandCluster(cluster Cluster, neighbours []Clusterable, visited map[Clusterable]bool, minPts int, eps float64) Cluster {
+func expandCluster(cluster Cluster, neighbours []Clusterable, visited map[string]bool, minPts int, eps float64) Cluster {
 	seed := make([]Clusterable, len(neighbours))
 	copy(seed, neighbours)
 	for _, point := range seed {
-		pointState, isVisited := visited[point]
+		pointState, isVisited := visited[point.GetID()]
 		if !isVisited {
 			currentNeighbours := findNeighbours(point, seed, eps)
-			if len(currentNeighbours) >= minPts {
+			if len(currentNeighbours)+1 >= minPts {
+				visited[point.GetID()] = CLUSTERED
 				cluster = merge(cluster, currentNeighbours)
 			}
 		}
 
 		if isVisited && pointState == NOISE {
-			visited[point] = CLUSTERED
+			visited[point.GetID()] = CLUSTERED
 			cluster = append(cluster, point)
 		}
 	}
@@ -65,12 +70,12 @@ func expandCluster(cluster Cluster, neighbours []Clusterable, visited map[Cluste
 }
 
 func merge(one []Clusterable, two []Clusterable) []Clusterable {
-	mergeMap := make(map[Clusterable]bool)
+	mergeMap := make(map[string]Clusterable)
 	putAll(mergeMap, one)
 	putAll(mergeMap, two)
 	merged := make([]Clusterable, 0)
-	for key := range mergeMap {
-		merged = append(merged, key)
+	for _, val := range mergeMap {
+		merged = append(merged, val)
 	}
 
 	return merged
@@ -78,8 +83,8 @@ func merge(one []Clusterable, two []Clusterable) []Clusterable {
 
 //Function to add all values from list to map
 //map keys is then the unique collecton from list
-func putAll(m map[Clusterable]bool, list []Clusterable) {
+func putAll(m map[string]Clusterable, list []Clusterable) {
 	for _, val := range list {
-		m[val] = true
+		m[val.GetID()] = val
 	}
 }

--- a/dbscan_test.go
+++ b/dbscan_test.go
@@ -1,6 +1,7 @@
 package dbscan
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"testing"
@@ -10,20 +11,20 @@ type SimpleClusterable struct {
 	position float64
 }
 
-func (s *SimpleClusterable) Distance(c Clusterable) float64 {
-	distance := math.Abs(c.GetParams()[0] - s.GetParams()[0])
+func (s SimpleClusterable) Distance(c interface{}) float64 {
+	distance := math.Abs(c.(SimpleClusterable).position - s.position)
 	return distance
 }
 
-func (s *SimpleClusterable) GetParams() []float64 {
-	return []float64{s.position}
+func (s SimpleClusterable) GetID() string {
+	return fmt.Sprint(s.position)
 }
 
 func TestPutAll(t *testing.T) {
-	testMap := make(map[Clusterable]bool)
+	testMap := make(map[string]Clusterable)
 	clusterList := []Clusterable{
-		&SimpleClusterable{10},
-		&SimpleClusterable{12},
+		SimpleClusterable{10},
+		SimpleClusterable{12},
 	}
 	putAll(testMap, clusterList)
 	mapSize := len(testMap)
@@ -36,34 +37,34 @@ func TestPutAll(t *testing.T) {
 func TestFindNeighbours(t *testing.T) {
 	log.Println("Executing TestFindNeighbours")
 	clusterList := []Clusterable{
-		&SimpleClusterable{0},
-		&SimpleClusterable{1},
-		&SimpleClusterable{2},
-		&SimpleClusterable{2},
-		&SimpleClusterable{2},
+		SimpleClusterable{0},
+		SimpleClusterable{1},
+		SimpleClusterable{-1},
+		SimpleClusterable{1.5},
+		SimpleClusterable{-0.5},
 	}
 
 	eps := 1.0
 	neighbours := findNeighbours(clusterList[0], clusterList, eps)
 
-	assertEquals(t, 1, len(neighbours))
+	assertEquals(t, 3, len(neighbours))
 }
 
 func TestMerge(t *testing.T) {
 	log.Println("Executing TestMerge")
 	expected := 6
 	one := []Clusterable{
-		&SimpleClusterable{0},
-		&SimpleClusterable{1},
-		&SimpleClusterable{2},
-		&SimpleClusterable{2},
-		&SimpleClusterable{2},
+		SimpleClusterable{0},
+		SimpleClusterable{1},
+		SimpleClusterable{2.1},
+		SimpleClusterable{2.2},
+		SimpleClusterable{2.3},
 	}
 
 	two := []Clusterable{
 		one[0],
 		one[1],
-		&SimpleClusterable{2},
+		SimpleClusterable{2.4},
 	}
 
 	output := merge(one, two)
@@ -72,18 +73,18 @@ func TestMerge(t *testing.T) {
 
 func TestExpandCluster(t *testing.T) {
 	log.Println("Executing TestExpandCluster")
-	expected := 3
+	expected := 4
 	clusterList := []Clusterable{
-		&SimpleClusterable{0},
-		&SimpleClusterable{1},
-		&SimpleClusterable{2},
-		&SimpleClusterable{2},
-		&SimpleClusterable{5},
+		SimpleClusterable{0},
+		SimpleClusterable{1},
+		SimpleClusterable{2},
+		SimpleClusterable{2.1},
+		SimpleClusterable{5},
 	}
 
 	eps := 1.0
 	minPts := 3
-	visitMap := make(map[Clusterable]bool)
+	visitMap := make(map[string]bool)
 	cluster := make(Cluster, 0)
 	cluster = expandCluster(cluster, clusterList, visitMap, minPts, eps)
 	assertEquals(t, expected, len(cluster))
@@ -92,18 +93,21 @@ func TestExpandCluster(t *testing.T) {
 func TestClusterize(t *testing.T) {
 	log.Println("Executing TestClusterize")
 	clusterList := []Clusterable{
-		&SimpleClusterable{1},
-		&SimpleClusterable{2},
-		&SimpleClusterable{2},
-		&SimpleClusterable{5},
-		&SimpleClusterable{6},
-		&SimpleClusterable{4},
-		&SimpleClusterable{5},
+		SimpleClusterable{1},
+		SimpleClusterable{0.5},
+		SimpleClusterable{0},
+		SimpleClusterable{5},
+		SimpleClusterable{4.5},
+		SimpleClusterable{4},
 	}
 	eps := 1.0
-	minPts := 3
+	minPts := 2
 	clusters := Clusterize(clusterList, minPts, eps)
 	assertEquals(t, 2, len(clusters))
+	if 2 == len(clusters) {
+		assertEquals(t, 3, len(clusters[0]))
+		assertEquals(t, 3, len(clusters[1]))
+	}
 }
 
 func TestClusterizeNoData(t *testing.T) {


### PR DESCRIPTION
This change provides better flexibility when using a Clusterable which it's GetParams function needs to return more than []float64.
Now in you could do:
```go
func (a *MyPoint) Distance(b interface{}) float64 {
	b2 := b.(MyPoint)
        //...
}
```

And you don't need `GetParams` anymore